### PR TITLE
Update jiffy dependency to 0.14.3

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 {deps,
   [
-    {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", {tag, "0.8.3"}}},
+    {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", {tag, "0.14.3"}}},
     {meck, ".*", {git, "https://github.com/horkhe/meck.git", {branch, "feature/wait"}}}
   ]}.


### PR DESCRIPTION
This library is a dependency for Zotonic, the updated dependency enables use of jiffy:decode/2 which is very convenient for decoding JSON to maps instead of structs.
